### PR TITLE
Ensure both sync and async method handlers work as expected

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ interface RPCResponse<T = any, E = any> {
 
 ```ts
 type SendRequestFunc = <P = any, R = any, E = any>(
-  request: RPCRequest<P>,
+  request: RPCRequest<P>
 ) => Promise<RPCResponse<R, E> | null>
 ```
 
@@ -67,29 +67,19 @@ interface RPCConnection {
 ### ErrorHandler
 
 ```ts
-type ErrorHandler<C = any> = <P = any>(
-  ctx: C,
-  req: RPCRequest<P>,
-  error: Error,
-) => void
+type ErrorHandler<C = any> = <P = any>(ctx: C, req: RPCRequest<P>, error: Error) => void
 ```
 
 ### MethodHandler
 
 ```ts
-type MethodHandler<C = any, P = any, R = any> = (
-  ctx: C,
-  params: P,
-) => R | Promise<R>
+type MethodHandler<C = any, P = any, R = any> = (ctx: C, params: P) => R | Promise<R>
 ```
 
 ### NotificationHandler
 
 ```ts
-type NotificationHandler<C = any> = <P = any>(
-  ctx: C,
-  req: RPCRequest<P>,
-) => void
+type NotificationHandler<C = any> = <P = any>(ctx: C, req: RPCRequest<P>) => void
 ```
 
 ### HandlerMethods
@@ -113,7 +103,7 @@ interface HandlerOptions<C = any> {
 ```ts
 type RequestHandler<C = any> = <P = any, R = any, E = any>(
   ctx: C,
-  msg: RPCRequest<P>,
+  msg: RPCRequest<P>
 ) => Promise<RPCResponse<R, E> | null>
 ```
 
@@ -251,3 +241,7 @@ Extends built-in `Error` class
 - `onNotification: NotificationHandler<C>`: callback used when receiving a JSON-RPC notification (no `id` present).
 
 When these options are not provided, fallbacks using `console.warn` will be called instead.
+
+## License
+
+MIT

--- a/package-lock.json
+++ b/package-lock.json
@@ -1496,9 +1496,9 @@
       }
     },
     "@typescript-eslint/types": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-3.7.0.tgz",
-      "integrity": "sha512-reCaK+hyKkKF+itoylAnLzFeNYAEktB0XVfSQvf0gcVgpz1l49Lt6Vo9x4MVCCxiDydA0iLAjTF/ODH0pbfnpg==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-3.7.1.tgz",
+      "integrity": "sha512-PZe8twm5Z4b61jt7GAQDor6KiMhgPgf4XmUb9zdrwTbgtC/Sj29gXP1dws9yEn4+aJeyXrjsD9XN7AWFhmnUfg==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
@@ -1525,9 +1525,9 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-3.7.0.tgz",
-      "integrity": "sha512-k5PiZdB4vklUpUX4NBncn5RBKty8G3ihTY+hqJsCdMuD0v4jofI5xuqwnVcWxfv6iTm2P/dfEa2wMUnsUY8ODw==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-3.7.1.tgz",
+      "integrity": "sha512-xn22sQbEya+Utj2IqJHGLA3i1jDzR43RzWupxojbSWnj3nnPLavaQmWe5utw03CwYao3r00qzXfgJMGNkrzrAA==",
       "dev": true,
       "requires": {
         "eslint-visitor-keys": "^1.1.0"
@@ -2951,27 +2951,27 @@
       }
     },
     "eslint-config-3box": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-3box/-/eslint-config-3box-0.1.1.tgz",
-      "integrity": "sha512-CCC4MRUNxZUTHUwyXiAgdrG+jnlTrvhhTYoPxb4USw1vfFgMDiJIls/NYs0Szoi+B3vToT2Un3pp7zZvD1HRPw==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-3box/-/eslint-config-3box-0.1.2.tgz",
+      "integrity": "sha512-nCvb+GhUNQmKaQjTaDwYaJ6oXJQZwn+dR769bBEHPOdBYFbkVhuTNLry2p0nj7Br+GypDKFtZgATSejXzd3RPw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/eslint-plugin": "^3.7.0",
-        "@typescript-eslint/parser": "^3.7.0",
+        "@typescript-eslint/eslint-plugin": "^3.7.1",
+        "@typescript-eslint/parser": "^3.7.1",
         "eslint-config-prettier": "^6.11.0",
-        "eslint-plugin-jest": "^23.18.2",
+        "eslint-plugin-jest": "^23.19.0",
         "eslint-plugin-prettier": "^3.1.4",
-        "eslint-plugin-react": "^7.20.4",
+        "eslint-plugin-react": "^7.20.5",
         "eslint-plugin-react-hooks": "^4.0.8"
       },
       "dependencies": {
         "@typescript-eslint/eslint-plugin": {
-          "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.7.0.tgz",
-          "integrity": "sha512-4OEcPON3QIx0ntsuiuFP/TkldmBGXf0uKxPQlGtS/W2F3ndYm8Vgdpj/woPJkzUc65gd3iR+qi3K8SDQP/obFg==",
+          "version": "3.7.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.7.1.tgz",
+          "integrity": "sha512-3DB9JDYkMrc8Au00rGFiJLK2Ja9CoMP6Ut0sHsXp3ZtSugjNxvSSHTnKLfo4o+QmjYBJqEznDqsG1zj4F2xnsg==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/experimental-utils": "3.7.0",
+            "@typescript-eslint/experimental-utils": "3.7.1",
             "debug": "^4.1.1",
             "functional-red-black-tree": "^1.0.1",
             "regexpp": "^3.0.0",
@@ -2980,39 +2980,39 @@
           }
         },
         "@typescript-eslint/experimental-utils": {
-          "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.7.0.tgz",
-          "integrity": "sha512-xpfXXAfZqhhqs5RPQBfAFrWDHoNxD5+sVB5A46TF58Bq1hRfVROrWHcQHHUM9aCBdy9+cwATcvCbRg8aIRbaHQ==",
+          "version": "3.7.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.7.1.tgz",
+          "integrity": "sha512-TqE97pv7HrqWcGJbLbZt1v59tcqsSVpWTOf1AqrWK7n8nok2sGgVtYRuGXeNeLw3wXlLEbY1MKP3saB2HsO/Ng==",
           "dev": true,
           "requires": {
             "@types/json-schema": "^7.0.3",
-            "@typescript-eslint/types": "3.7.0",
-            "@typescript-eslint/typescript-estree": "3.7.0",
+            "@typescript-eslint/types": "3.7.1",
+            "@typescript-eslint/typescript-estree": "3.7.1",
             "eslint-scope": "^5.0.0",
             "eslint-utils": "^2.0.0"
           }
         },
         "@typescript-eslint/parser": {
-          "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-3.7.0.tgz",
-          "integrity": "sha512-2LZauVUt7jAWkcIW7djUc3kyW+fSarNEuM3RF2JdLHR9BfX/nDEnyA4/uWz0wseoWVZbDXDF7iF9Jc342flNqQ==",
+          "version": "3.7.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-3.7.1.tgz",
+          "integrity": "sha512-W4QV/gXvfIsccN8225784LNOorcm7ch68Fi3V4Wg7gmkWSQRKevO4RrRqWo6N/Z/myK1QAiGgeaXN57m+R/8iQ==",
           "dev": true,
           "requires": {
             "@types/eslint-visitor-keys": "^1.0.0",
-            "@typescript-eslint/experimental-utils": "3.7.0",
-            "@typescript-eslint/types": "3.7.0",
-            "@typescript-eslint/typescript-estree": "3.7.0",
+            "@typescript-eslint/experimental-utils": "3.7.1",
+            "@typescript-eslint/types": "3.7.1",
+            "@typescript-eslint/typescript-estree": "3.7.1",
             "eslint-visitor-keys": "^1.1.0"
           }
         },
         "@typescript-eslint/typescript-estree": {
-          "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.7.0.tgz",
-          "integrity": "sha512-xr5oobkYRebejlACGr1TJ0Z/r0a2/HUf0SXqPvlgUMwiMqOCu/J+/Dr9U3T0IxpE5oLFSkqMx1FE/dKaZ8KsOQ==",
+          "version": "3.7.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.7.1.tgz",
+          "integrity": "sha512-m97vNZkI08dunYOr2lVZOHoyfpqRs0KDpd6qkGaIcLGhQ2WPtgHOd/eVbsJZ0VYCQvupKrObAGTOvk3tfpybYA==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "3.7.0",
-            "@typescript-eslint/visitor-keys": "3.7.0",
+            "@typescript-eslint/types": "3.7.1",
+            "@typescript-eslint/visitor-keys": "3.7.1",
             "debug": "^4.1.1",
             "glob": "^7.1.6",
             "is-glob": "^4.0.1",
@@ -3031,9 +3031,9 @@
           }
         },
         "eslint-plugin-react": {
-          "version": "7.20.4",
-          "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.20.4.tgz",
-          "integrity": "sha512-y4DOQ0LrzuDQFEAnYFGjJMRHQQqfTco02qiWI00eGQYikHTzC15S5aRHGWSffnThv8sBpsmFBLky3K5keniAJg==",
+          "version": "7.20.5",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.20.5.tgz",
+          "integrity": "sha512-ajbJfHuFnpVNJjhyrfq+pH1C0gLc2y94OiCbAXT5O0J0YCKaFEHDV8+3+mDOr+w8WguRX+vSs1bM2BDG0VLvCw==",
           "dev": true,
           "requires": {
             "array-includes": "^3.1.1",
@@ -3202,9 +3202,9 @@
       }
     },
     "eslint-plugin-jest": {
-      "version": "23.18.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-23.18.2.tgz",
-      "integrity": "sha512-afVOE47F0PENnRlnePUHgrDbv1tsDlTAVrjL051oUETB2ImzBwa5GfmUAUhDjAEuxH+xkE6DsmEpZ8obXzUMqQ==",
+      "version": "23.19.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-23.19.0.tgz",
+      "integrity": "sha512-l5PLflALqnODl8Yy0H5hDs18aKJS1KTf66VZGXRpIhmbLbPLaTuMB2P+65fBpkdseSpnTVcIlBYvTvJSBi/itg==",
       "dev": true,
       "requires": {
         "@typescript-eslint/experimental-utils": "^2.5.0"
@@ -5739,9 +5739,9 @@
       "optional": true
     },
     "nanoid": {
-      "version": "3.1.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.11.tgz",
-      "integrity": "sha512-HyrIRpCB2uS1/sEoS7/UIAM/Jn72uXf2/yWgQRP0e16/UdMsfH/1JyLj2SqyQlkMkeeN1ad61tpT6FPRRimxnA=="
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
+      "integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -7886,9 +7886,9 @@
       }
     },
     "tslib": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz",
-      "integrity": "sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+      "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==",
       "dev": true
     },
     "tsutils": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rpc-utils",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "Paul Le Cam <paul@3box.io>",
   "license": "MIT",
   "main": "dist/index.js",
@@ -21,14 +21,14 @@
     "prepare": "tsdx build"
   },
   "dependencies": {
-    "nanoid": "^3.1.11"
+    "nanoid": "^3.1.12"
   },
   "devDependencies": {
     "@types/nanoid": "^2.1.0",
-    "eslint-config-3box": "^0.1.1",
+    "eslint-config-3box": "^0.1.2",
     "husky": "^4.2.5",
     "tsdx": "^0.13.2",
-    "tslib": "^2.0.0",
+    "tslib": "^2.0.1",
     "typescript": "^3.9.7"
   },
   "husky": {

--- a/src/client.ts
+++ b/src/client.ts
@@ -14,10 +14,7 @@ export class RPCClient {
     return nanoid()
   }
 
-  public async request<P = any, R = any>(
-    method: string,
-    params?: P
-  ): Promise<R> {
+  public async request<P = any, R = any>(method: string, params?: P): Promise<R> {
     const res = await this.connection.send<P, R>({
       jsonrpc: '2.0',
       id: this.createID(),

--- a/src/error.ts
+++ b/src/error.ts
@@ -22,8 +22,7 @@ export function isServerError(code: number): boolean {
 
 export function getErrorMessage(code: number): string {
   return (
-    ERROR_MESSAGE[code.toString()] ??
-    (isServerError(code) ? 'Server error' : 'Application error')
+    ERROR_MESSAGE[code.toString()] ?? (isServerError(code) ? 'Server error' : 'Application error')
   )
 }
 
@@ -36,11 +35,7 @@ export class RPCError<T = any> extends Error {
   public data: T | undefined
   public message: string
 
-  public constructor(
-    code: number,
-    message?: string | undefined,
-    data?: T | undefined
-  ) {
+  public constructor(code: number, message?: string | undefined, data?: T | undefined) {
     super()
     Object.setPrototypeOf(this, RPCError.prototype)
 
@@ -66,11 +61,7 @@ function createErrorFactory(code: ERROR_CODE): <T>(data?: T) => RPCError<T> {
 }
 
 export const createParseError = createErrorFactory(ERROR_CODE.PARSE_ERROR)
-export const createInvalidRequest = createErrorFactory(
-  ERROR_CODE.INVALID_REQUEST
-)
-export const createMethodNotFound = createErrorFactory(
-  ERROR_CODE.METHOD_NOT_FOUND
-)
+export const createInvalidRequest = createErrorFactory(ERROR_CODE.INVALID_REQUEST)
+export const createMethodNotFound = createErrorFactory(ERROR_CODE.METHOD_NOT_FOUND)
 export const createInvalidParams = createErrorFactory(ERROR_CODE.INVALID_PARAMS)
 export const createInternalError = createErrorFactory(ERROR_CODE.INTERNAL_ERROR)

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,26 +1,11 @@
-import {
-  ERROR_CODE,
-  RPCError,
-  createParseError,
-  getErrorMessage
-} from './error'
+import { ERROR_CODE, RPCError, createParseError, getErrorMessage } from './error'
 import { RPCRequest, RPCResponse } from './types'
 
-export type ErrorHandler<C = any> = <P = any>(
-  ctx: C,
-  req: RPCRequest<P>,
-  error: Error
-) => void
+export type ErrorHandler<C = any> = <P = any>(ctx: C, req: RPCRequest<P>, error: Error) => void
 
-export type MethodHandler<C = any, P = any, R = any> = (
-  ctx: C,
-  params: P
-) => R | Promise<R>
+export type MethodHandler<C = any, P = any, R = any> = (ctx: C, params: P) => R | Promise<R>
 
-export type NotificationHandler<C = any> = <P = any>(
-  ctx: C,
-  req: RPCRequest<P>
-) => void
+export type NotificationHandler<C = any> = <P = any>(ctx: C, req: RPCRequest<P>) => void
 
 export type HandlerMethods<C = any> = Record<string, MethodHandler<C>>
 
@@ -43,10 +28,7 @@ export function parseJSON<T = any>(input: string): T {
   }
 }
 
-export function createErrorResponse<R, E>(
-  id: number | string,
-  code: number
-): RPCResponse<R, E> {
+export function createErrorResponse<R, E>(id: number | string, code: number): RPCResponse<R, E> {
   return {
     jsonrpc: '2.0',
     id,
@@ -54,27 +36,17 @@ export function createErrorResponse<R, E>(
   }
 }
 
-function fallbackOnHandlerError<C = any, P = any>(
-  _ctx: C,
-  msg: RPCRequest<P>,
-  error: Error
-): void {
+function fallbackOnHandlerError<C = any, P = any>(_ctx: C, msg: RPCRequest<P>, error: Error): void {
   // eslint-disable-next-line no-console
   console.warn('Unhandled handler error', msg, error)
 }
 
-function fallbackOnInvalidMessage<C = any, P = any>(
-  _ctx: C,
-  msg: RPCRequest<P>
-): void {
+function fallbackOnInvalidMessage<C = any, P = any>(_ctx: C, msg: RPCRequest<P>): void {
   // eslint-disable-next-line no-console
   console.warn('Unhandled invalid message', msg)
 }
 
-function fallbackOnNotification<C = any, P = any>(
-  _ctx: C,
-  msg: RPCRequest<P>
-): void {
+function fallbackOnNotification<C = any, P = any>(_ctx: C, msg: RPCRequest<P>): void {
   // eslint-disable-next-line no-console
   console.warn('Unhandled notification', msg)
 }
@@ -112,7 +84,8 @@ export function createHandler<C = any>(
     }
 
     try {
-      const result = await handler(ctx, msg.params ?? {})
+      const handled = handler(ctx, msg.params ?? {})
+      const result = typeof handled.then === 'function' ? await handled : handled
       return { jsonrpc: '2.0', id, result }
     } catch (err) {
       let error

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -36,8 +36,6 @@ describe('client', () => {
       })
     }) as SendRequestFunc
     const client = new RPCClient({ send })
-    await expect(client.request('test_method', 'hello')).rejects.toThrow(
-      RPCError
-    )
+    await expect(client.request('test_method', 'hello')).rejects.toThrow(RPCError)
   })
 })

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -54,10 +54,7 @@ describe('server', () => {
     })
 
     expect(onInvalidMessage).toHaveBeenCalledTimes(1)
-    expect(onInvalidMessage).toHaveBeenCalledWith(
-      { ctx: true },
-      { method: 'test' }
-    )
+    expect(onInvalidMessage).toHaveBeenCalledWith({ ctx: true }, { method: 'test' })
   })
 
   test('createHandler() handles invalid "method" key', async () => {
@@ -78,10 +75,7 @@ describe('server', () => {
     })
 
     expect(onInvalidMessage).toHaveBeenCalledTimes(1)
-    expect(onInvalidMessage).toHaveBeenCalledWith(
-      { ctx: true },
-      { jsonrpc: '2.0' }
-    )
+    expect(onInvalidMessage).toHaveBeenCalledWith({ ctx: true }, { jsonrpc: '2.0' })
   })
 
   test('createHandler() handles notifications', async () => {
@@ -90,19 +84,13 @@ describe('server', () => {
     const res = await handle({ ctx: true }, { jsonrpc: '2.0', method: 'test' })
     expect(res).toBeNull()
     expect(onNotification).toHaveBeenCalledTimes(1)
-    expect(onNotification).toHaveBeenCalledWith(
-      { ctx: true },
-      { jsonrpc: '2.0', method: 'test' }
-    )
+    expect(onNotification).toHaveBeenCalledWith({ ctx: true }, { jsonrpc: '2.0', method: 'test' })
   })
 
   test('createHandler() handles not found methods', async () => {
     const code = ERROR_CODE.METHOD_NOT_FOUND
     const handle = createHandler({})
-    const res = await handle(
-      { ctx: true },
-      { jsonrpc: '2.0', id: 'test', method: 'test' }
-    )
+    const res = await handle({ ctx: true }, { jsonrpc: '2.0', id: 'test', method: 'test' })
     expect(res).toEqual({
       jsonrpc: '2.0',
       id: 'test',
@@ -113,13 +101,26 @@ describe('server', () => {
   test('createHandler() handles successful handler return', async () => {
     const handle = createHandler({
       // @ts-ignore
-      test: jest.fn((ctx, { name }) => `hello ${name}`)
+      testAsync: jest.fn((ctx, { name }) => Promise.resolve(`hello ${name}`)),
+      // @ts-ignore
+      testSync: jest.fn((ctx, { name }) => `hello ${name}`)
     })
-    const res = await handle(
+
+    const resAsync = await handle(
       { ctx: true },
-      { jsonrpc: '2.0', id: 'test', method: 'test', params: { name: 'bob' } }
+      { jsonrpc: '2.0', id: 'test', method: 'testAsync', params: { name: 'alice' } }
     )
-    expect(res).toEqual({
+    expect(resAsync).toEqual({
+      jsonrpc: '2.0',
+      id: 'test',
+      result: 'hello alice'
+    })
+
+    const resSync = await handle(
+      { ctx: true },
+      { jsonrpc: '2.0', id: 'test', method: 'testSync', params: { name: 'bob' } }
+    )
+    expect(resSync).toEqual({
       jsonrpc: '2.0',
       id: 'test',
       result: 'hello bob'


### PR DESCRIPTION
@oed it's mostly formatting fixes but the main change is an added test to ensure both sync and async methods are properly handled: https://github.com/ceramicnetwork/js-rpc-utils/compare/handle-methods?expand=1#diff-af97d367d22aed1d7fd6801b8c925384R104-R106
This way we could make the changes in IDW a bit less verbose if needed.